### PR TITLE
Fix cask package name

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -72,7 +72,7 @@ cask 'quicklook-csv'
 cask 'qlstephen'
 
 # Fonts
-cask 'font-sauce-code-powerline'
+cask 'font-source-code-pro-for-powerline'
 cask 'font-source-code-pro'
 cask 'font-source-sans-pro'
 cask 'font-source-serif-pro'


### PR DESCRIPTION
Good sauce btw.
The new name is `font-source-code-pro-for-powerline`