### PR TITLE
Bypass file path prompt

### DIFF
--- a/ssh.sh
+++ b/ssh.sh
@@ -4,7 +4,7 @@ echo "Generating a new SSH key for GitHub..."
 
 # Generating a new SSH key
 # https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key
-ssh-keygen -t ed25519 -C $1
+ssh-keygen -t ed25519 -C $1 -f ~/.ssh/id_ed25519
 
 # Adding your SSH key to the ssh-agent
 # https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent


### PR DESCRIPTION
While stealing this (🚔) I saw a mini optimization I thought I'd contribute back.

As you expect the file path to be the default later in the script, we can specify the file path while generating the key to bypass the prompt.

With this option set, it will just jump to asking for the passphrase....

<img width="736" alt="Screen Shot 2021-03-28 at 12 39 34 pm" src="https://user-images.githubusercontent.com/24803032/112739762-af281880-8fc2-11eb-8490-2b771d6218dc.png">
