### PR TITLE
Correct SSH public key name

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -1,5 +1,5 @@
 # Shortcuts
-alias copyssh="pbcopy < $HOME/.ssh/id_rsa.pub"
+alias copyssh="pbcopy < $HOME/.ssh/id_ed25519.pub"
 alias reloadshell="source $HOME/.zshrc"
 alias reloaddns="dscacheutil -flushcache && sudo killall -HUP mDNSResponder"
 alias ll="/usr/local/opt/coreutils/libexec/gnubin/ls -AhlFo --color --group-directories-first"


### PR DESCRIPTION
The SSH key generated in the `ssh.sh` script is named after the type (ed25519) of key created, i.e. id_ed25519. However, the alias for copying the SSH key is referring to the rsa type.