### PR TITLE
Updating System Updates preferences to work with macOS Monterey

### DIFF
--- a/.macos
+++ b/.macos
@@ -755,22 +755,22 @@ defaults write com.apple.appstore WebKitDeveloperExtras -bool true
 # defaults write com.apple.appstore ShowDebugMenu -bool true
 
 # Enable the automatic update check
-defaults write com.apple.SoftwareUpdate AutomaticCheckEnabled -bool true
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist AutomaticCheckEnabled -bool true
 
 # Check for software updates daily, not just once per week
 defaults write com.apple.SoftwareUpdate ScheduleFrequency -int 1
 
 # Download newly available updates in background
-defaults write com.apple.SoftwareUpdate AutomaticDownload -int 1
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist AutomaticDownload -bool true
 
 # Install System data files & security updates
-defaults write com.apple.SoftwareUpdate CriticalUpdateInstall -int 1
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist CriticalUpdateInstall -bool true
 
 # Automatically download apps purchased on other Macs
-# defaults write com.apple.SoftwareUpdate ConfigDataInstall -int 1
+# sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist ConfigDataInstall -bool true
 
 # Turn on app auto-update
-defaults write com.apple.commerce AutoUpdate -bool true
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate.plist AutoUpdate -bool true
 
 # Allow the App Store to reboot machine on macOS updates
 # defaults write com.apple.commerce AutoUpdateRestartRequired -bool true


### PR DESCRIPTION
Confirmed updates for System Preferences -> Software Update. Works with macOS Monterey!