### PR TITLE
Updated reference for erasing and reinstalling macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First, go through the checklist below to make sure you didn't forget anything be
 
 ### Installing macOS cleanly
 
-After going through our checklist above and making sure you backed everything up, we're going to cleanly install macOS with the latest release. Follow [this article](https://www.imore.com/how-do-clean-install-macos) to cleanly install the latest macOS version.
+After going through our checklist above and making sure you backed everything up, we're going to cleanly install macOS with the latest release. Follow [this article](https://support.apple.com/guide/mac-help/erase-and-reinstall-macos-mh27903/mac) to cleanly install the latest macOS version.
 
 ### Setting up your Mac
 


### PR DESCRIPTION
The current URL for explaining how to erase and re-install macOS is broken. This article from Apple is concise, and has references for both Intel and M1 Macs.