### PR TITLE
add `.gitmodules` file for existing submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugins/artisan"]
+	path = plugins/artisan
+	url = git@github.com:jessarcher/zsh-artisan.git


### PR DESCRIPTION
The plugin `plugins/artisan` was added as a submodule[^1] without the corresponding `.gitmodules` entry.

This pull request adds a `.gitmodules` file to fix #84.

[^1]: https://github.com/driesvints/dotfiles/commit/70dcbeece8