### PR TITLE
Update Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,4 @@
 # Taps
-tap 'homebrew/cask'
 tap 'homebrew/cask-fonts'
 tap 'homebrew/cask-versions'
 tap 'homebrew/bundle'


### PR DESCRIPTION
Got the following message when running `brew update`

```sh
Installing from the API is now the default behaviour!
You can save space and time by running:
  brew untap homebrew/core
  brew untap homebrew/cask
```