### PR TITLE
Use `omz reload` to reload shell correctly

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -1,6 +1,6 @@
 # Shortcuts
 alias copyssh="pbcopy < $HOME/.ssh/id_ed25519.pub"
-alias reloadshell="source $HOME/.zshrc"
+alias reloadshell="omz reload"
 alias reloaddns="dscacheutil -flushcache && sudo killall -HUP mDNSResponder"
 alias ll="/opt/homebrew/opt/coreutils/libexec/gnubin/ls -AhlFo --color --group-directories-first"
 alias phpstorm='open -a /Applications/PhpStorm.app "`pwd`"'


### PR DESCRIPTION
According to [How do I reload the zshrc file?](https://github.com/ohmyzsh/ohmyzsh/wiki/FAQ#how-do-i-reload-the-zshrc-file) under oh-my-zsh repo, it is important to reload your shell using `exec zsh` rather than `source ~/.zshrc`. In fact, it will slow down your shell if you source it multiple times. `omz reload` effectivly call [exec zsh](https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/cli.zsh#L632)