### PR TITLE
Add Xcode Command Line Tools installation check

### DIFF
--- a/fresh.sh
+++ b/fresh.sh
@@ -2,6 +2,14 @@
 
 echo "Setting up your Mac..."
 
+# Check if Xcode Command Line Tools are installed
+if ! xcode-select -p &>/dev/null; then
+  echo "Xcode Command Line Tools not found. Installing..."
+  xcode-select --install
+else
+  echo "Xcode Command Line Tools already installed."
+fi
+
 # Check for Oh My Zsh and install if we don't have it
 if test ! $(which omz); then
   /bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/HEAD/tools/install.sh)"


### PR DESCRIPTION
This PR adds a check for Xcode Command Line Tools at the beginning of the setup process.
If the tools aren't installed, it prompts the installation automatically.

This addresses an issue where a fresh macOS install might not have these tools available,
which are required for several subsequent steps including Homebrew installation.

Added as suggested in the closed issue: https://github.com/driesvints/dotfiles/issues/96