### PR TITLE
fix: remove `Homebrew/homebrew-bundle` from `Brewfile`

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,6 @@
 # Taps
 tap 'homebrew/cask-fonts'
 tap 'homebrew/cask-versions'
-tap 'homebrew/bundle'
 tap 'stripe/stripe-cli'
 
 # Binaries


### PR DESCRIPTION
It's now merged into core brew
https://github.com/Homebrew/homebrew-bundle